### PR TITLE
Add a workflow to create release pull request

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,14 +14,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install ghch
+      id: setup-ghch
       run: |
-        mkdir -p ./ghch/
-        curl -fsSL https://github.com/Songmu/ghch/releases/download/${GHCH_VERSION}/ghch_${GHCH_VERSION}_linux_amd64.tar.gz | tar -xz --strip-components 1 -C ./ghch
+        TEMPDIR=$(mktemp -d)
+        curl -fsSL https://github.com/Songmu/ghch/releases/download/${GHCH_VERSION}/ghch_${GHCH_VERSION}_linux_amd64.tar.gz | tar -xz --strip-components 1 -C $TEMPDIR
+        echo "::set-output name=ghch-path::$TEMPDIR/ghch"
       env:
         GHCH_VERSION: v0.10.2
     - name: Generate New Changelog
       run: |
-        ./ghch/ghch -w --next-version=${{ github.event.inputs.nextVersion }}
+        ${{ steps.setup-ghch.outputs.ghch-path }} -w --next-version=${{ github.event.inputs.nextVersion }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Pull Request

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,6 +21,7 @@ jobs:
         echo "::set-output name=ghch-path::$TEMPDIR/ghch"
       env:
         GHCH_VERSION: v0.10.2
+        TZ: Asia/Tokyo
     - name: Generate New Changelog
       run: |
         ${{ steps.setup-ghch.outputs.ghch-path }} -w --next-version=${{ github.event.inputs.nextVersion }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,4 @@
-name: Create Relaese Pull Request
+name: Create Release Pull Request
 
 on:
   workflow_dispatch:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
     - name: install ghch
       id: setup-ghch
       run: |

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       nextVersion:
-        description: 'Next Version'
+        description: 'Next Version (vX.Y.Z)'
         required: true
-        default: 'vX.Y.Z'
 jobs:
   create-release-pull-request:
     name: Create Release Pull Request

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,40 @@
+name: Create Relaese Pull Request
+
+on:
+  workflow_dispatch:
+    inputs:
+      nextVersion:
+        description: 'Next Version'
+        required: true
+        default: 'vX.Y.Z'
+jobs:
+  create-release-pull-request:
+    name: Create Release Pull Request
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install ghch
+      run: |
+        mkdir -p ./ghch/
+        curl -fsSL https://github.com/Songmu/ghch/releases/download/${GHCH_VERSION}/ghch_${GHCH_VERSION}_linux_amd64.tar.gz | tar -xz --strip-components 1 -C ./ghch
+      env:
+        GHCH_VERSION: v0.10.2
+    - name: Generate New Changelog
+      run: |
+        ./ghch/ghch -w --next-version=${{ github.event.inputs.nextVersion }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        # token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # TODO: Without this configuration, this p-r does not trigger another workflow (= CI)
+        branch-suffix: timestamp
+        branch: release-${{ github.event.inputs.nextVersion}}
+        commit-message: Prepare for release ${{ github.event.inputs.nextVersion}}
+        title: Release ${{ github.event.inputs.nextVersion}}
+        body: |
+          ## How to release this version
+          1. Review and modify CHANGELOG.md
+          2. Merge this pull request
+          3. `git checkout main && git pull && git tag ${{ github.event.inputs.nextVersion }} && git push --tags`
+          4. Wait a while, and check https://github.com/${{ github.repository}}/releases/tag/${{ github.event.inputs.nextVersion }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+# RELEASE
+
+Start a release workflow from https://github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/actions?query=workflow%3A%22Create+Relaese+Pull+Request%22

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 # RELEASE
 
-Start a release workflow from https://github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/actions?query=workflow%3A%22Create+Relaese+Pull+Request%22
+Start a release workflow from https://github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/actions?query=workflow%3A%22Create+Release+Pull+Request%22


### PR DESCRIPTION
You can see what will happen in my sandbox repo: https://github.com/astj/sandbox-github-actions

Add a workflow to create a release pull request.  In this pull request, CHANGELOG.md will be prepared (like https://github.com/astj/sandbox-github-actions/pull/3).

One might imagine about automation of `git checkout main && git pull && git tag ${{ github.event.inputs.nextVersion }} && git push --tags`.
Yes it *IS* possible, but it needs Personal Access Token due to limitation to `GITHUB_TOKEN` (see https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow), since pushing tags should trigger release workflow (#3).

Rather than using Personal Access Token, I'd like to leave these process for human being ;-)