### PR TITLE
Use `fields @message` for --return

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ command = ["check-aws-cloudwatch-logs-insights", "--log-group-name", "/aws/lambd
   -w, --warning-over=WARNING                             Trigger a warning if matched lines is over a number
   -c, --critical-over=CRITICAL                           Trigger a critical if matched lines is over a number
   -s, --state-dir=DIR                                    Dir to keep state files under
-  -r, --return                                           Output earliest log found with given query
+  -r, --return                                           Output matched log messages (Up to 10 messages)
 ```
 
 The plugin uses the instance profile if possible, or you can configure `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` environment variables in the `env` settings.

--- a/lib/app.go
+++ b/lib/app.go
@@ -239,6 +239,7 @@ func parseResult(out *cloudwatchlogs.GetQueryResultsOutput) (*ParsedQueryResults
 		for _, field := range fields {
 			if field.Field != nil && *field.Field == "@message" && field.Value != nil {
 				res.ReturnedMessages = append(res.ReturnedMessages, *field.Value)
+				break
 			}
 		}
 	}

--- a/lib/app.go
+++ b/lib/app.go
@@ -40,7 +40,7 @@ type logOpts struct {
 	WarningOver   int    `short:"w" long:"warning-over" value-name:"WARNING" description:"Trigger a warning if matched lines is over a number"`
 	CriticalOver  int    `short:"c" long:"critical-over" value-name:"CRITICAL" description:"Trigger a critical if matched lines is over a number"`
 	StateDir      string `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under" unquote:"false"`
-	ReturnMessage bool   `short:"r" long:"return" description:"Output earliest log found with given query"`
+	ReturnMessage bool   `short:"r" long:"return" description:"Output matched log messages (Up to 10 messages)"`
 	Debug         bool   `long:"debug" description:"Enable debug log"`
 }
 


### PR DESCRIPTION
Closes #1

now we can simplly use returned `@message` as source of `--return`.