### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hatena/mackerel-check-aws-cloudwatch-logs-insights
+module github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/hatena/mackerel-check-aws-cloudwatch-logs-insights/lib"
+import "github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/lib"
 
 func main() {
 	checkawscloudwatchlogsinsights.Do()


### PR DESCRIPTION
module path still points to our private repository for initial development.