### PR TITLE
Migrate repository and graduate from Beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.label, 'mackerelio-labs:release-v')
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.label, 'mackerelio:release-v')
     steps:
       - name: Extract version tag from branch name
         id: extract-version

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# check-aws-cloudwatch-logs-insights (BETA)
+# check-aws-cloudwatch-logs-insights
 
 ## Description
 Checks Amazon CloudWatch Logs using CloudWatch Logs Insights.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 # RELEASE
 
-Start a release workflow from https://github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/actions?query=workflow%3A%22Create+Release+Pull+Request%22
+Start a release workflow from https://github.com/mackerelio/check-aws-cloudwatch-logs-insights/actions?query=workflow%3A%22Create+Release+Pull+Request%22

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights
+module github.com/mackerelio/check-aws-cloudwatch-logs-insights
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/mackerelio-labs/check-aws-cloudwatch-logs-insights/lib"
+import "github.com/mackerelio/check-aws-cloudwatch-logs-insights/lib"
 
 func main() {
 	checkawscloudwatchlogsinsights.Do()


### PR DESCRIPTION
This repo is moved from mackerelio-labs/check-aws-cloudwatch-logs-insights to mackerelio/check-aws-cloudwatch-logs-insights .
In this p-r, I-d like to:
- change URLs points to old repositories
  - I left [CHANGELOG](https://github.com/mackerelio/check-aws-cloudwatch-logs-insights/blob/main/CHANGELOG.md) as is
- Remove "(BETA)" from README.

TODOs:
- [ ] Change link in README: https://github.com/mackerelio/check-aws-cloudwatch-logs-insights/blob/main/README.md#description
  - I need new blog posts!
- [ ] release a new version (v0.1.0)

